### PR TITLE
Ignore env and python bytecode cache folders.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 # Generated files
 .docusaurus
+env
+__pycache__
 
 # Misc
 .DS_Store
@@ -7,4 +9,3 @@
 .env.development.local
 .env.test.local
 .env.production.local
-env

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 .env.development.local
 .env.test.local
 .env.production.local
+env

--- a/tutraffic-app/.gitignore
+++ b/tutraffic-app/.gitignore
@@ -1,5 +1,8 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
+# Generated files
+/backend/__pycache__
+
 # dependencies
 /node_modules
 /.pnp

--- a/tutraffic-app/.gitignore
+++ b/tutraffic-app/.gitignore
@@ -1,8 +1,5 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
-# Generated files
-/backend/__pycache__
-
 # dependencies
 /node_modules
 /.pnp


### PR DESCRIPTION
Configure git to ignore directories related generated from building the backend.