### PR TITLE
Fix and reposition codespaces button/badge.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-[![Open in Codespaces](https://classroom.github.com/assets/launch-codespace-f4981d0f882b2a3f0472912d15f9806d57e124e0fc890972558857b51b24a6f9.svg)](https://classroom.github.com/open-in-codespaces?assignment_repo_id=10118243)
 <div align="center">
 
 # TuTraffic
@@ -7,6 +6,7 @@
 [![Documentation Website Link](https://img.shields.io/badge/-Documentation%20Website-brightgreen)](https://capstone-projects-2023-spring.github.io/project-tutraffic/)
 [![TuTraffic App Link](https://img.shields.io/badge/-TuTraffic--App-red)](https://tutrafficdatabase.web.app/)
 
+[![Open in Codespaces](https://github.com/codespaces/badge.svg)](https://classroom.github.com/open-in-codespaces?assignment_repo_id=10118243)
 
 </div>
 


### PR DESCRIPTION
1. Fixes the image reference for the "Open in GitHub Codespaces" button/badge in the documentation home page.
2. Repositions the badge below the other badges.

It appears as follows:
![image](https://user-images.githubusercontent.com/40096469/233153514-2f12c2a4-966e-4bd7-8534-de1b560f6f82.png)
