### PR TITLE
Prevent null exception and update user filter.

### DIFF
--- a/frontend/src/components/Browse.js
+++ b/frontend/src/components/Browse.js
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { LotData } from './LotData';
+import { UserLotData } from './UserLotData';
 import { calculateDistance } from './utils';
 import { FaHeart } from 'react-icons/fa';
 import { db, auth } from '../firebase';
@@ -44,7 +45,7 @@ const Browse = () => {
     }, 1000);
   };
 
-
+  const { userLotType, userCarType, userPriceType } = UserLotData(user?.uid);
   const renderData = () => {
     if (!data) {
       return <p>Loading...</p>;
@@ -55,7 +56,11 @@ const Browse = () => {
         const distance = calculateDistance(latitude, longitude, data[key].lat, data[key].lng);
         return { key, distance, ...data[key] };
       })
-      .filter((item) => !isNaN(item.distance))
+      .filter((item) => (!isNaN(item.distance)
+        && (userLotType === 'all' || userLotType === item.street)
+        && (item.maxsize < userCarType)
+        && (item.free || (item.free !== userPriceType))
+      ))
       .sort((a, b) => a.distance - b.distance);
 
     return sortedData.map(({ key, name, spots, street, distance, Captured }) => (

--- a/frontend/src/components/Browse.js
+++ b/frontend/src/components/Browse.js
@@ -58,7 +58,7 @@ const Browse = () => {
       })
       .filter((item) => (!isNaN(item.distance)
         && (userLotType === 'all' || userLotType === item.street)
-        && (item.maxsize < userCarType)
+        && (item.maxsize >= userCarType)
         && (item.free || (item.free !== userPriceType))
       ))
       .sort((a, b) => a.distance - b.distance);

--- a/frontend/src/components/Map.js
+++ b/frontend/src/components/Map.js
@@ -104,9 +104,9 @@ const Map = () => {
 
   const { userLotType, userCarType, userPriceType } = UserLotData(currentUser?.uid);
   const markers = data ? Object.keys(data)
-    .filter((key) => (userLotType !== 'defualt' ? data[key].street === userLotType : true))
-    .filter((key) => (userCarType !== 'defualt' ? data[key].maxsize >= userCarType : true))
-    .filter((key) => (userPriceType !== 'defualt' ? data[key].free === userPriceType : true))
+    .filter((key) => (userLotType !== 'all' ? data[key].street === userLotType : true))
+    .filter((key) => (data[key].maxsize >= userCarType))
+    .filter((key) => (userPriceType !== 'all' ? data[key].free === userPriceType : true))
     .map((key) => {
       const { lat, lng, spots, street } = data[key];
       if (lat && lng) {

--- a/frontend/src/components/Map.js
+++ b/frontend/src/components/Map.js
@@ -106,7 +106,7 @@ const Map = () => {
   const markers = data ? Object.keys(data)
     .filter((key) => (userLotType !== 'all' ? data[key].street === userLotType : true))
     .filter((key) => (data[key].maxsize >= userCarType))
-    .filter((key) => (userPriceType !== 'all' ? data[key].free === userPriceType : true))
+    .filter((key) => (data[key].free || data[key].free === userPriceType))
     .map((key) => {
       const { lat, lng, spots, street } = data[key];
       if (lat && lng) {

--- a/frontend/src/components/UserLotData.js
+++ b/frontend/src/components/UserLotData.js
@@ -3,29 +3,35 @@ import { db } from '../firebase';
 import { doc, getDoc } from 'firebase/firestore';
 
 export const UserLotData = (userId) => {
-  const [userLotType, setLotType] = useState('defualt');
-  const [userCarType, setCarType] = useState('defualt');
-  const [userPriceType, setPriceType] = useState('defualt');
+  const [userLotType, setLotType] = useState('all');
+  const [userCarType, setCarType] = useState(0);
+  const [userPriceType, setPriceType] = useState('all');
 
   useEffect(() => {
     if (!userId) {
-      setLotType('defualt');
-      setCarType('defualt');
-      setPriceType('defualt');
+      setLotType('all');
+      setCarType(0);
+      setPriceType('all');
       return;
     }
 
     const fetchUserData = async () => {
       const userDoc = doc(db, 'users', userId);
       const snapshot = await getDoc(userDoc);
-      const userData = snapshot.exists() ? snapshot.data() : null;
+      if (!snapshot.exists()) {
+        setLotType('all');
+        setCarType(0);
+        setPriceType('all');
+        return;
+      }
+      const userData = snapshot.data()
 
       if (userData.lotType === 'street') {
         setLotType(true);
       } else if (userData.lotType === 'lot') {
         setLotType(false);
       } else {
-        setLotType('defualt');
+        setLotType('all');
       }
 
       if (userData.CarSize === 'Small') {
@@ -35,14 +41,15 @@ export const UserLotData = (userId) => {
       } else if (userData.CarSize === 'Large') {
         setCarType(5);
       } else {
-        setCarType('defualt');
+        setCarType(0);
       }
+
       if (userData.priceType === 'free') {
         setPriceType(true);
       } else if (userData.priceType === 'notFree') {
         setPriceType(false);
       } else {
-        setPriceType('defualt');
+        setPriceType('all');
       }
     };
 


### PR DESCRIPTION
Quick and dirty way to prevent script from reading properties of null.
Prevent null exception on userData.
Refactor 'defualt' to 'all'.
Add filters to browse page, and update price filter to reduce to 'free' or 'all' cases, excluding the 'paid' case.